### PR TITLE
support NATS 2.0 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Configuration is by environment variable, which can be set in the Kubernetes YAM
 | -------------------- | ------------------------------|--------------------------------------------------|
 | `topics`             | Delimited list of topics    |  `nats-test,`                                   |
 | `broker_host`        | The host, but not the port for NATS | `nats` |
+| `broker_credentials` | Path to a NATS credentials file for authenticated connections | unauthenticated |
 | `async-invocation`   | Queue the invocation with the built-in OpenFaaS queue-worker and return immediately    |  `false` |
 | `gateway_url`        | The URL for the OpenFaaS gateway | `http://gateway:8080` |
 | `upstream_timeout`   | Timeout to wait for synchronous invocations | `60s` |

--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,9 @@ const defaultUpstreamTimeout = time.Second * 60
 
 // Config for the NATS Connector
 type Config struct {
-	Broker string
-	Topics []string
+	Broker      string
+	Topics      []string
+	Credentials string
 
 	GatewayURL               string
 	UpstreamTimeout          time.Duration
@@ -99,6 +100,7 @@ func Get() Config {
 	return Config{
 		Broker:                   broker,
 		Topics:                   topics,
+		Credentials:              os.Getenv("broker_credentials"),
 		GatewayURL:               gatewayURL,
 		UpstreamTimeout:          upstreamTimeout,
 		RebuildInterval:          rebuildInterval,

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 	brokerConfig := nats.BrokerConfig{
 		Host:        config.Broker,
 		ConnTimeout: config.UpstreamTimeout, // ConnTimeout isn't the same as UpstreamTimeout, it's just the delay to connect to NATS.
+		Credentials: config.Credentials,
 	}
 
 	fmt.Printf(`==============================================================================
@@ -41,6 +42,7 @@ NATS Connector for OpenFaaS
 
 Gateway URL: %s
 NATS URL: nats://%s:4222
+Credentials: %s
 Topics: %s
 Upstream timeout: %s
 Topic-map rebuild interval: %s
@@ -49,6 +51,7 @@ Async invocation: %q
 
 `, config.GatewayURL,
 		config.Broker,
+		config.Credentials,
 		config.UpstreamTimeout,
 		config.Topics,
 		config.RebuildInterval,


### PR DESCRIPTION
This adds support for specifying a NATS 2.0 credentials file to
allow authenticated connections to the NATS broker.

Also sets up reconnection support and a bit of extra logging
about the lifecycle of the NATS connection

Signed-off-by: R.I.Pienaar <rip@devco.net>