### PR TITLE
Updated the k8s manifest to reference the recently published 0.2.4 container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nats-connector
 
-[![Docker Build Status](https://github.com/openfaas-incubator/nats-connector/workflows/docker/badge.svg)](https://github.com/openfaas-incubator/nats-connector/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/openfaas-incubator/nats-connector)](https://goreportcard.com/report/github.com/openfaas-incubator/nats-connector)
-[![GoDoc](https://godoc.org/github.com/openfaas-incubator/nats-connector?status.svg)](https://godoc.org/github.com/openfaas-incubator/nats-connector)
+[![Docker Build Status](https://github.com/openfaas/nats-connector/workflows/build/badge.svg)](https://github.com/openfaas/nats-connector/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/openfaas/nats-connector)](https://goreportcard.com/report/github.com/openfaas/nats-connector)
+[![GoDoc](https://godoc.org/github.com/openfaas/nats-connector?status.svg)](https://godoc.org/github.com/openfaas/nats-connector)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![OpenFaaS](https://img.shields.io/badge/openfaas-serverless-blue.svg)](https://www.openfaas.com)
 

--- a/yaml/connector-swarm.yaml
+++ b/yaml/connector-swarm.yaml
@@ -21,7 +21,7 @@ services:
           - 'node.platform.os == linux'
 
   connector:
-    image: openfaas/nats-connector:0.2.0
+    image: openfaas/nats-connector:0.2.4
     hostname: nats-connector
     environment:
       gateway_url: http://gateway:8080

--- a/yaml/kubernetes/connector-dep.yaml
+++ b/yaml/kubernetes/connector-dep.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: nats-connector
-        image: openfaas/nats-connector:0.2.2
+        image: ghcr.io/openfaas/nats-connector:0.2.4
         env:
           - name: upstream_timeout
             value: "1m1s"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The example kubernetes manifest file has been updated to reference GHCR
The readme has also been updated to point at the correct badges

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Docker containers for OpenFaas are now stored on the GitHub Container registry
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local deployment using the name image URL

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
